### PR TITLE
Add settings link to pop-up form

### DIFF
--- a/src/background/SettingsService.js
+++ b/src/background/SettingsService.js
@@ -57,7 +57,7 @@ class SettingsService {
 
     async getLanguage() {
         const { language = DefaultSettings.Language } = await new Promise((resolve) => {
-            chrome.storage.local.get('language2', resolve);
+            chrome.storage.local.get('language', resolve);
         });
         return Languages[language] ?? DefaultSettings.Language;
     }

--- a/src/background/SettingsService.js
+++ b/src/background/SettingsService.js
@@ -1,4 +1,4 @@
-import { DefaultSettings , Languages} from '../scripts/defaultSettings'
+import { AllSettingsNames, DefaultSettings , Languages} from '../scripts/defaultSettings'
 
 class SettingsService { 
 
@@ -56,13 +56,9 @@ class SettingsService {
     }
 
     async getLanguage() {
-        const { language } = await new Promise((resolve) => {
-            chrome.storage.local.get('language', resolve);
+        const { language = DefaultSettings.Language } = await new Promise((resolve) => {
+            chrome.storage.local.get('language2', resolve);
         });
-        
-        if (!language) {
-            language = DefaultSettings.Language;
-        }
         return Languages[language] ?? DefaultSettings.Language;
     }
 
@@ -71,6 +67,18 @@ class SettingsService {
             chrome.storage.local.get('displayTokens', resolve);
         });
         return !!displayTokens;
+    }
+
+    async shouldUserUpdateSettings() {
+        const settings = await new Promise((resolve) => {
+            chrome.storage.local.get(AllSettingsNames, resolve);
+        });
+
+        const keyValues = Object.entries(settings);
+        if (keyValues.length !== AllSettingsNames.length) {
+            return true;
+        }
+        return keyValues.find(([_, value]) => value === undefined) !== undefined;
     }
 }
 

--- a/src/content/PopupManager.js
+++ b/src/content/PopupManager.js
@@ -11,6 +11,7 @@ class PopupManager {
         explanationLink.classList.add('explanation-link');
         explanationLink.classList.add('default-color');
         explanationLink.textContent = 'See Explanation';
+        explanationLink.title = "Show explanations for selected text"
         explanationLink.addEventListener('click', async (event) => {
             event.preventDefault();
             const explanation = await this.fetchExplanation(text);
@@ -21,6 +22,19 @@ class PopupManager {
         });
 
         return explanationLink;
+    }
+
+    createSettingsLink() {
+        const settingsLink = document.createElement('a');
+        settingsLink.href = '#';
+        settingsLink.classList.add('settings-link');
+        settingsLink.classList.add('default-color');
+        settingsLink.innerHTML = '&#x2699; Settings';
+        settingsLink.title = "Update settings"
+        settingsLink.target = "_blank";
+        settingsLink.href = chrome.runtime.getURL('src/views/settings.html');
+
+        return settingsLink;
     }
 
     async show({ translation, text, action }) {
@@ -56,6 +70,11 @@ class PopupManager {
                 const explanationLink = this.createExplanationLink();
                 popup.appendChild(explanationLink);
             }
+        }
+
+        if (await SettingsService.shouldUserUpdateSettings()) {
+            const settingsLink = this.createSettingsLink();
+            popup.appendChild(settingsLink);
         }
 
         document.body.appendChild(popup);

--- a/src/scripts/defaultSettings.js
+++ b/src/scripts/defaultSettings.js
@@ -204,3 +204,13 @@ export const Languages = {
     za:"Zhuang, Chuang",
     zu: "Zulu"
 }
+
+export const AllSettingsNames = [
+    'OPENAI_API_KEY',
+    'alwaysDisplayExplanation',
+    'language',
+    'gptModel',
+    'maxTokens',
+    'getTranslationAsHtml',
+    'displayTokens'
+]

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -1,4 +1,4 @@
-import { DefaultSettings, Languages } from './defaultSettings.js'
+import { AllSettingsNames, DefaultSettings, Languages } from './defaultSettings.js'
 
 let gptModelsForOptions = {
     "gpt-4o": 'gpt-4o',
@@ -69,15 +69,7 @@ const loadAllGptModels = async () => {
 
 document.addEventListener('DOMContentLoaded', () => {
     // Load and display the saved settings if they exist
-    chrome.storage.local.get([
-        'OPENAI_API_KEY',
-        'alwaysDisplayExplanation',
-        'language',
-        'gptModel',
-        'maxTokens',
-        'getTranslationAsHtml',
-        'displayTokens'
-    ], function (result) {
+    chrome.storage.local.get(AllSettingsNames, function (result) {
         const model = document.getElementById('gpt-model');
         model.value = result.gptModel ?? DefaultSettings.gptModel;
         if (result.OPENAI_API_KEY) {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -27,6 +27,13 @@
   font-family: Arial, sans-serif;
 }
 
+#translation-popup pre {
+  box-shadow:none;
+  border:unset;
+  margin:0;
+  padding:0;
+}
+
 #translation-popup a {
   text-decoration: underline;
   font-size: .75em;
@@ -91,4 +98,10 @@
 .navbar-popup {
   width: 300px;
   font-size: 16px;
+}
+
+#translation-popup .settings-link {
+  position: absolute;
+  right:16px;
+  bottom:16px;
 }


### PR DESCRIPTION
@johnlewissims Added settings link to the pop-up form with the translation.

If a user has any extension setting with a value `undefined` then the **Settings** link will be displayed:
![image](https://github.com/user-attachments/assets/b31fae00-fbb1-4466-9786-cd82352f5a88)

otherwise, the link will be hidden:
![image](https://github.com/user-attachments/assets/4c8cb6a0-4f56-46bb-8ce2-be58ec86db1f)

The "Settings form" saves a value for all settings.