### PR TITLE
Add manual language selection option to improve translation accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.js
 node_modules/
 dist/
 .vscode/
+debug.js

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Translate selected text and provide explanations and breakdowns.",
   "main": "index.js",
   "scripts": {
-    "build": "webpack",
+    "start": "webpack --mode development --devtool inline-source-map --watch",
+    "build": "webpack --mode production",
     "lint": "npx eslint **/*.js  & npx stylelint **/*.css",
     "lint-js": "npx eslint **/*.js",
     "lint-css": "npx stylelint **/*.css"

--- a/src/HtmlFunc/attributes.js
+++ b/src/HtmlFunc/attributes.js
@@ -1,0 +1,15 @@
+export const enableElementById = (id) => {
+    document.getElementById(id).removeAttribute('disabled');
+};
+
+export const disableElementById = (id) => {
+    document.getElementById(id).setAttribute('disabled', true);
+};
+
+export const hideElementById = (id) => {
+    document.getElementById(id).classList.add('hidden');
+};
+
+export const showElementById = (id) => {
+    document.getElementById(id).classList.remove('hidden');
+};

--- a/src/HtmlFunc/options.js
+++ b/src/HtmlFunc/options.js
@@ -1,0 +1,38 @@
+/**
+ * Create options for Select.
+ *
+ * @param {string} selectElementId
+ * @param {Array|Object} optionsAsObjectWithKeyValueOrArray
+ * @returns
+ */
+export const createOptions = (
+    selectElementId,
+    optionsAsObjectWithKeyValueOrArray,
+) => {
+    const selectElement = document.getElementById(selectElementId);
+    if (!selectElement) {
+        return;
+    }
+
+    const options = Array.isArray(optionsAsObjectWithKeyValueOrArray)
+        ? optionsAsObjectWithKeyValueOrArray
+        : Object.entries(optionsAsObjectWithKeyValueOrArray);
+
+    for (const pair of options) {
+        const option = document.createElement('option');
+        option.value = pair[0];
+        option.text = pair[1];
+        selectElement.appendChild(option);
+    }
+};
+
+export const clearAllChild = (selectElementId) => {
+    const selectElement = document.getElementById(selectElementId);
+    if (!selectElement) {
+        return;
+    }
+
+    while (selectElement.firstChild) {
+        selectElement.firstChild.remove();
+    }
+};

--- a/src/background/LanguageDetection.js
+++ b/src/background/LanguageDetection.js
@@ -1,6 +1,12 @@
 import { Languages } from '../scripts/defaultSettings';
 
-const getLanguageHint = (languageCode = '', targetLanguage = '') => {
+/**
+ * Get language name by its code.
+ *
+ * @param {string} languageCode it's a key of Languages.
+ * @returns {string}
+ */
+export const getLanguage = (languageCode) => {
     if (!languageCode) {
         return '';
     }
@@ -11,18 +17,30 @@ const getLanguageHint = (languageCode = '', targetLanguage = '') => {
         codeOnly = languageCode.split('-')[0]?.toLocaleLowerCase() ?? '';
     }
     if (codeOnly) {
-        const language = Languages[codeOnly];
-        if (language) {
-            if (
-                language.toLocaleLowerCase() ===
-                targetLanguage.toLocaleLowerCase()
-            ) {
-                return '';
-            }
-            return language;
-        }
+        return Languages[codeOnly] ?? '';
     }
     return '';
 };
 
-export { getLanguageHint };
+/**
+ * Get source text language.
+ *
+ * @param {string} languageCode it's a key of Languages.
+ * @param {string} targetLanguage language name. It's a value of Languages.
+ * @returns {string}
+ */
+export const getLanguageHint = (languageCode = '', targetLanguage = '') => {
+    if (!languageCode) {
+        return '';
+    }
+    const language = getLanguage(languageCode);
+    if (language) {
+        if (
+            language.toLocaleLowerCase() === targetLanguage.toLocaleLowerCase()
+        ) {
+            return '';
+        }
+        return language;
+    }
+    return '';
+};

--- a/src/background/OpenAIService.js
+++ b/src/background/OpenAIService.js
@@ -1,4 +1,4 @@
-import { getLanguageHint } from './LanguageDetection.js';
+import { getLanguage, getLanguageHint } from './LanguageDetection.js';
 import SettingsService from './SettingsService.js';
 
 class OpenAIService {
@@ -76,19 +76,75 @@ class OpenAIService {
         return text && text?.length < 50 && text.split(' ').length < 5;
     }
 
-    getOutBlocksMessages(language, isDetailedTranslation = false) {
+    /**
+     * Get set of instructions for GPT how to translate text.
+     *
+     * @param {string} language target language from settings.
+     * @param {string} isDetailedTranslation type of translation short/detailed.
+     * @param {string} userDefinedLanguage source language was defined by user.
+     * @returns {[{role:string, content:string}]}
+     */
+    getOutBlocksMessages(
+        language,
+        isDetailedTranslation = false,
+        userDefinedLanguage = '',
+    ) {
         if (isDetailedTranslation) {
+            if (userDefinedLanguage) {
+                return [
+                    { role: 'user', content: 'Output must contain 4 blocks.' },
+                    {
+                        role: 'user',
+                        content: `1: Detected language is ${userDefinedLanguage}.`,
+                    },
+                    {
+                        role: 'user',
+                        content: `2: Translation from ${userDefinedLanguage} to ${language}.`,
+                    },
+                    {
+                        role: 'user',
+                        content: `3: Description of the options for using the text in ${language}.`,
+                    },
+                    {
+                        role: 'user',
+                        content: `4: Three examples with text in ${userDefinedLanguage} language with translation to ${language}.`,
+                    },
+                    {
+                        role: 'user',
+                        content: `Block headers must be in ${language}}.`,
+                    },
+                ];
+            } else {
+                return [
+                    { role: 'user', content: 'Output must contain 4 blocks.' },
+                    { role: 'user', content: '1: Detected language.' },
+                    { role: 'user', content: `2: Translation to ${language}.` },
+                    {
+                        role: 'user',
+                        content: `3: Description of the options for using the text in ${language}.`,
+                    },
+                    {
+                        role: 'user',
+                        content: `4: Three examples with text in detected language with translation to ${language}.`,
+                    },
+                    {
+                        role: 'user',
+                        content: `Block headers must be in ${language}}.`,
+                    },
+                ];
+            }
+        }
+
+        if (userDefinedLanguage) {
             return [
-                { role: 'user', content: 'Output must contain 4 blocks.' },
-                { role: 'user', content: '1: Detected language.' },
-                { role: 'user', content: `2: Translation to ${language}.` },
+                { role: 'user', content: 'Output must contain 2 blocks.' },
                 {
                     role: 'user',
-                    content: `3: Description of the options for using the text in ${language}.`,
+                    content: `1: Detected language is ${userDefinedLanguage}.`,
                 },
                 {
                     role: 'user',
-                    content: `4: Three examples with text in detected language with translation to ${language}.`,
+                    content: `2: Translation from ${userDefinedLanguage} to ${language}}.`,
                 },
                 {
                     role: 'user',
@@ -105,34 +161,92 @@ class OpenAIService {
         ];
     }
 
+    /**
+     * Get hint for GPT about source language.
+     *
+     * @param {string} languageCode - source language code, was defined by HTML attributes.
+     * @param {string} userDefinedLanguage - source language, was defined by user.
+     * @param {string} language target language from settings.
+     * @returns {[{role:string, content:string}]}
+     */
+    getLanguageHintMessage(languageCode, userDefinedLanguage, language) {
+        const languageHint = getLanguageHint(languageCode, language);
+        if (!userDefinedLanguage) {
+            return languageHint
+                ? [
+                      {
+                          role: 'user',
+                          content: `I think this text in ${languageHint} language.`,
+                      },
+                  ]
+                : [];
+        }
+
+        return [
+            {
+                role: 'system',
+                content: `Translate text from ${userDefinedLanguage} to ${language}.`,
+            },
+        ];
+    }
+
+    /**
+     * Get GPT instructions that depend on userDefinedLanguage.
+     *
+     * @param {string} userDefinedLanguage - source language, was defined by user.
+     * @param {string} language target language from settings.
+     * @returns {[{role:string, content:string}]}
+     */
+    getDetectLanguageInstruction(userDefinedLanguage, language) {
+        return userDefinedLanguage
+            ? []
+            : [
+                  { role: 'system', content: `User language is ${language}.` },
+                  { role: 'system', content: 'Detect text language.' },
+              ];
+    }
+
+    /**
+     * Translate text.
+     *
+     * @param {string} text selected text on web page.
+     * @param {string} languageCode key of Languages.
+     * @param {boolean} isDetailedTranslation
+     * @param {string} userDefinedLanguageCode key of Languages.
+     *
+     * @returns {string} translation in plain text or HTML.
+     */
     async translateText(
         text,
         languageCode = '',
         isDetailedTranslation = false,
+        userDefinedLanguageCode = '',
     ) {
         const language = await SettingsService.getLanguage();
+        const userDefinedLanguage = getLanguage(userDefinedLanguageCode);
         const isTranslationAsHtml =
             await SettingsService.getTranslationAsHtml();
         const outputBlocksDescription = this.getOutBlocksMessages(
             language,
             isDetailedTranslation,
+            userDefinedLanguage,
         );
-        const languageHint = getLanguageHint(languageCode, language);
-        const languageHintMessage = languageHint
-            ? [
-                  {
-                      role: 'user',
-                      content: `I think this text in ${languageHint} language.`,
-                  },
-              ]
-            : [];
+        const languageHintMessage = this.getLanguageHintMessage(
+            languageCode,
+            userDefinedLanguage,
+            language,
+        );
+
+        const detectLanguageInstruction = this.getDetectLanguageInstruction(
+            userDefinedLanguage,
+            language,
+        );
         const messages = [
             {
                 role: 'system',
                 content: 'You are a helpful assistant that translates text.',
             },
-            { role: 'system', content: `User language is ${language}.` },
-            { role: 'system', content: 'Detect text language.' },
+            ...detectLanguageInstruction,
             ...languageHintMessage,
             { role: 'user', content: `Output must be in ${language}.` },
             ...outputBlocksDescription,

--- a/src/background/SelectionService.js
+++ b/src/background/SelectionService.js
@@ -1,4 +1,10 @@
 class SelectionService {
+    /**
+     * Get language code from HTML.
+     *
+     * @param {Node | null} anchorNode
+     * @returns {string}
+     */
     getLanguageCode(anchorNode) {
         // Try to get a language code from the nearest parent.
         let node = anchorNode;
@@ -11,6 +17,11 @@ class SelectionService {
         return document?.documentElement?.lang?.toUpperCase() ?? '';
     }
 
+    /**
+     * Get selected text from web page.
+     *
+     * @returns {string | undefined}
+     */
     getSelectedText() {
         const selection = window.getSelection();
         const selectedText = selection?.toString().trim();

--- a/src/background/SettingsService.js
+++ b/src/background/SettingsService.js
@@ -2,6 +2,12 @@ import { ErrorMessages } from '../constants/errorMessages';
 import { DefaultSettings, Languages } from '../scripts/defaultSettings';
 
 class SettingsService {
+    /** Settings used by extension
+     * but users can't set them directly on Settings page.*/
+    innerSettings = {
+        popupFavoriteLanguages: 'popupFavoriteLanguages',
+    };
+
     async getGptModel() {
         const { gptModel = DefaultSettings.GptModel } = await new Promise(
             (resolve) => {
@@ -72,6 +78,35 @@ class SettingsService {
             chrome.storage.local.get('displayTokens', resolve);
         });
         return !!displayTokens;
+    }
+
+    async getPopupFavoriteLanguages() {
+        const savedValues = await new Promise((resolve) => {
+            chrome.storage.local.get(
+                this.innerSettings.popupFavoriteLanguages,
+                resolve,
+            );
+        });
+
+        return savedValues[this.innerSettings.popupFavoriteLanguages] ?? {};
+    }
+
+    /**
+     * Add new language into saved settings.
+     *
+     * @param {string} language language code, key of Languages.
+     * @returns
+     */
+    async savePopupFavoriteLanguages(language) {
+        if (!language) {
+            return;
+        }
+        const savedLanguages = await this.getPopupFavoriteLanguages();
+        savedLanguages[language] = 1 + (savedLanguages[language] ?? 0);
+        chrome.storage.local.set(
+            { [this.innerSettings.popupFavoriteLanguages]: savedLanguages },
+            () => void 0,
+        );
     }
 }
 

--- a/src/background/TranslationService.js
+++ b/src/background/TranslationService.js
@@ -1,17 +1,14 @@
 class TranslationService {
     /**
      * Get translation.
-     * @param {MessageActions} action
-     * @param {string} text
-     * @param {keyof Languages} languageCode - language code
+     * @param {{
+     * action: string,
+     * text: string,
+     * languageCode?: keyof Languages,
+     * isDetailed?: boolean }} message
      * @param {(response) => void} callback - chrome sendMessage callback.
      */
-    handleTranslation(action, text, languageCode, callback) {
-        const message = {
-            action,
-            text,
-            languageCode,
-        };
+    handleTranslation(message, callback) {
         chrome.runtime.sendMessage(message, callback);
     }
 }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -36,12 +36,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             },
         );
     } else if (message.action === MessageActions.translateAndExplain) {
-        OpenAIService.translateText(message.text, message.languageCode)
+        OpenAIService.translateText(
+            message.text,
+            message.languageCode,
+            message.isDetailed ?? false,
+            message.userDefinedLanguageCode,
+        )
             .then((response) => {
                 sendResponse({
                     ...response,
                     text: message.text,
                     action: message.action,
+                    isDetailed: message.isDetailed ?? false,
                 });
             })
             .catch((error) => {
@@ -49,12 +55,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             });
         return true;
     } else if (message.action === MessageActions.translateDetailed) {
-        OpenAIService.translateText(message.text, message.languageCode, true)
+        OpenAIService.translateText(
+            message.text,
+            message.languageCode,
+            message.isDetailed ?? true,
+            message.userDefinedLanguageCode ?? '',
+            message.userDefinedLanguageCode,
+        )
             .then((response) => {
                 sendResponse({
                     ...response,
                     text: message.text,
                     action: message.action,
+                    isDetailed: message.isDetailed ?? true,
+                    userDefinedLanguageCode: message.userDefinedLanguageCode,
                 });
             })
             .catch((error) => {

--- a/src/constants/messageActions.js
+++ b/src/constants/messageActions.js
@@ -1,4 +1,5 @@
 export const MessageActions = {
+    // TODO: remove translateDetailed
     translateDetailed: 'translateDetailed',
     translateAndExplain: 'translateAndExplain',
     fetchExplanation: 'fetchExplanation',

--- a/src/content/PopupManager.js
+++ b/src/content/PopupManager.js
@@ -1,46 +1,168 @@
+import { Languages } from '../scripts/defaultSettings.js';
 import SettingsService from '../background/SettingsService.js';
 import TranslationService from '../background/TranslationService.js';
 import { MessageActions } from '../constants/messageActions.js';
 import '../styles/styles.css';
 
 import TranslateIcon from './TranslateIcon.js';
+import { createOptions } from '../HtmlFunc/options.js';
+import {
+    disableElementById,
+    enableElementById,
+    hideElementById,
+} from '../HtmlFunc/attributes.js';
+import { getURL } from './chrome.js';
 
 class PopupManager {
+    action = '';
+    text = '';
+    isDetailed = false;
+
+    updatingTextColor = '#666';
+    changeLanguageSelectId = 'translation-popup-language';
+    changeLanguageTranslateButtonId = 'change-lang-form-submit';
+    explanationLinkId = 'translation-popup-explanation-link';
+
     createExplanationLink(text, popup) {
         const explanationLink = document.createElement('a');
         explanationLink.href = '#';
+        explanationLink.id = this.explanationLinkId;
         explanationLink.classList.add('explanation-link');
         explanationLink.classList.add('default-color');
         explanationLink.textContent = 'See Explanation';
         explanationLink.addEventListener('click', async (event) => {
             event.preventDefault();
+            hideElementById(this.explanationLinkId);
             const explanation = await this.fetchExplanation(text);
-            const explanationParagraph = document.createElement('p');
-            explanationParagraph.innerHTML = `<div class="explanation"><strong>Explanation:</strong> ${explanation}</div>`;
-            popup.appendChild(explanationParagraph);
-            explanationLink.style.display = 'none';
+            const explanationBlock = document.createElement('div');
+            explanationBlock.classList.add('explanation');
+            explanationBlock.innerHTML = `<strong>Explanation:</strong> ${explanation}`;
+            popup.appendChild(explanationBlock);
         });
 
         return explanationLink;
     }
 
-    async show({ translation, text, action }) {
+    createChangeLanguageFrom() {
+        const innerHTML = `<form id="change-lang-form">
+            <label for="${this.changeLanguageSelectId}">Text language:</label>
+            <select id="${this.changeLanguageSelectId}" name="language"></select>
+            <button id="${this.changeLanguageTranslateButtonId}">Translate</button>
+        </form>`;
+
+        return innerHTML;
+    }
+
+    getElementChangeLanguageSelect() {
+        return document.getElementById(this.changeLanguageSelectId);
+    }
+
+    /**
+     * Get selected language code value
+     *
+     * @returns {string}
+     */
+    getValueChangeLanguageSelect() {
+        return this.getElementChangeLanguageSelect().value;
+    }
+
+    /**
+     * Set selected language code value.
+     * @param {string} value
+     */
+    setValueChangeLanguageSelect(value) {
+        const element = this.getElementChangeLanguageSelect();
+        element.value = value;
+    }
+
+    async updateLanguageWithLastUsed() {
+        const savedUsedLanguages =
+            await SettingsService.getPopupFavoriteLanguages();
+        if (Object.keys(savedUsedLanguages).length === 0) {
+            savedUsedLanguages.en = 0;
+        }
+        const orderedFavoriteLanguages = Object.entries({
+            ...savedUsedLanguages,
+        }).sort((a, b) => b[1] - a[1]);
+        const allLanguagesWithoutFavorites = { ...Languages };
+        for (const lang of orderedFavoriteLanguages) {
+            lang[1] = allLanguagesWithoutFavorites[lang[0]];
+            delete allLanguagesWithoutFavorites[lang[0]];
+        }
+
+        const allLanguagesInRightOrder = [
+            ...orderedFavoriteLanguages,
+            ...Object.entries(allLanguagesWithoutFavorites),
+        ];
+
+        createOptions(this.changeLanguageSelectId, allLanguagesInRightOrder);
+
+        const favoriteLanguageKeyValue = orderedFavoriteLanguages[0];
+        this.setValueChangeLanguageSelect(favoriteLanguageKeyValue[0]);
+    }
+
+    async updateTranslationWithSelectedLanguage(event) {
+        event.preventDefault();
+        const selectedLanguage = this.getValueChangeLanguageSelect();
+        if (selectedLanguage) {
+            await SettingsService.savePopupFavoriteLanguages(selectedLanguage);
+        }
+
+        const translationElement = document.getElementById(
+            'translation-popup-text',
+        );
+
+        translationElement.style.color = this.updatingTextColor;
+        const pre = translationElement.getElementsByTagName('pre');
+        if (pre && pre.length === 1) {
+            pre[0].style.color = this.updatingTextColor;
+        }
+
+        disableElementById(this.changeLanguageTranslateButtonId);
+
+        const newTranslation = await new Promise((resolve, reject) => {
+            const message = {
+                action: this.action,
+                text: this.text,
+                languageCode: selectedLanguage,
+                isDetailed: this.isDetailed,
+                userDefinedLanguageCode: selectedLanguage,
+            };
+            TranslationService.handleTranslation(message, (response) => {
+                enableElementById(this.changeLanguageTranslateButtonId);
+                if (response.error) {
+                    reject(response.error);
+                } else {
+                    resolve(response.translation);
+                }
+            });
+        });
+
+        translationElement.innerHTML = newTranslation;
+    }
+
+    async show({ translation, text, action, isDetailed }) {
+        this.text = text;
+        this.action = action;
+        this.isDetailed = isDetailed;
+
         const popup = document.createElement('div');
         popup.id = 'translation-popup';
         const translationSection = document.createElement('div');
         translationSection.className = 'translation-section';
         translationSection.innerHTML = `
             <div class="translation">
-                <p>
+                <div>
                     <strong>Translation:</strong>
                     <b>${text}</b>
-                </p>
-                <p>
+                    ${this.createChangeLanguageFrom()}
+                </div>
+                <div id="translation-popup-text">
                     ${translation}
-                </p>
+                </div>
             </div>
             <div class="pronunciation">
-                <img src="${chrome.runtime.getURL('icons/speaker.png')}" alt="Play translation" id="ttsIcon">
+                <img src="${getURL('icons/speaker.png')}" alt="Play translation" id="ttsIcon">
             </div>
         `;
 
@@ -62,12 +184,22 @@ class PopupManager {
 
         document.body.appendChild(popup);
 
+        await this.updateLanguageWithLastUsed();
+        const changeLangFormSubmitHandler =
+            this.updateTranslationWithSelectedLanguage.bind(this);
+        document
+            .getElementById('change-lang-form')
+            .addEventListener('submit', changeLangFormSubmitHandler);
+
         const hidePopup = (event) => {
             if (
                 popup &&
                 !popup.contains(event.target) &&
                 event.target !== TranslateIcon.icon
             ) {
+                this.text = '';
+                this.action = '';
+                this.isDetailed = false;
                 popup.remove();
                 TranslateIcon.hide();
                 document.removeEventListener('mousedown', hidePopup);
@@ -80,9 +212,10 @@ class PopupManager {
     async fetchExplanation(text) {
         return new Promise((resolve, reject) => {
             TranslationService.handleTranslation(
-                MessageActions.fetchExplanation,
-                text,
-                '',
+                {
+                    action: MessageActions.fetchExplanation,
+                    text,
+                },
                 (response) => {
                     if (response.error) {
                         reject(response.error);
@@ -97,9 +230,10 @@ class PopupManager {
     async playTextToSpeech(text) {
         return new Promise((resolve, reject) => {
             TranslationService.handleTranslation(
-                MessageActions.textToSpeech,
-                text,
-                '',
+                {
+                    action: MessageActions.textToSpeech,
+                    text,
+                },
                 (response) => {
                     if (response.error) {
                         reject(response.error);

--- a/src/content/TranslateIcon.js
+++ b/src/content/TranslateIcon.js
@@ -5,6 +5,7 @@ import SettingsService from '../background/SettingsService.js';
 import SelectionService from '../background/SelectionService.js';
 import TranslationService from '../background/TranslationService.js';
 import { ErrorMessages } from '../constants/errorMessages.js';
+import { getURL } from './chrome.js';
 
 class TranslateIcon {
     MAX_LENGTH_TEXT_FOR_TRANSLATION = 500;
@@ -33,7 +34,7 @@ class TranslateIcon {
                 const iconLoaderUrl = icon.getAttribute(
                     this.CustomIconAttributes.iconLoaderUrl,
                 );
-                icon.src = chrome.runtime.getURL(iconLoaderUrl);
+                icon.src = getURL(iconLoaderUrl);
             } else if (icon) {
                 icon.style.display = 'none';
             }
@@ -48,7 +49,7 @@ class TranslateIcon {
             const iconUrl = icon.getAttribute(
                 this.CustomIconAttributes.iconUrl,
             );
-            icon.src = chrome.runtime.getURL(iconUrl);
+            icon.src = getURL(iconUrl);
         });
     }
 
@@ -63,6 +64,7 @@ class TranslateIcon {
                 translation: response.translation,
                 text: response.text,
                 action: response.action,
+                isDetailed: response.isDetailed,
             });
         }
     }
@@ -86,7 +88,7 @@ class TranslateIcon {
         icon.style.padding = '0';
         icon.style.backgroundColor = 'white';
         icon.style.borderRadius = '4px';
-        icon.src = chrome.runtime.getURL(iconUrl);
+        icon.src = getURL(iconUrl);
         icon.setAttribute('data-icon-url', iconUrl);
         icon.setAttribute('data-icon-loader-url', this.LOADER_URL);
         return icon;
@@ -177,10 +179,7 @@ class TranslateIcon {
             (err) => {
                 if (err.message === ErrorMessages.APIKeyNotSet) {
                     window
-                        .open(
-                            chrome.runtime.getURL('views/settings.html'),
-                            '_blank',
-                        )
+                        .open(getURL('views/settings.html'), '_blank')
                         .focus();
                 } else if (err.message) {
                     alert(err.message);
@@ -205,13 +204,16 @@ class TranslateIcon {
             this.resetIcons();
             return;
         }
+        const isDetailed = action === MessageActions.translateDetailed;
         const callbackTranslation = this.translationResponseHandler.bind(this);
-        TranslationService.handleTranslation(
+        const message = {
             action,
-            selectedText,
+            text: selectedText,
             languageCode,
-            callbackTranslation,
-        );
+            isDetailed,
+        };
+
+        TranslationService.handleTranslation(message, callbackTranslation);
     }
 }
 

--- a/src/content/chrome.js
+++ b/src/content/chrome.js
@@ -1,0 +1,1 @@
+export const getURL = (url) => chrome.runtime.getURL(url);

--- a/src/content/development.js
+++ b/src/content/development.js
@@ -1,0 +1,1 @@
+export const IsDevelopment = false;

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1,7 +1,9 @@
+import { getURL } from '../content/chrome';
+
 document.addEventListener('DOMContentLoaded', () => {
     const settingsLinks = document.querySelectorAll('.settings-link');
     settingsLinks.forEach((link) => {
-        link.href = chrome.runtime.getURL('views/settings.html');
+        link.href = getURL('views/settings.html');
     });
 
     chrome.storage.local.get(

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -1,3 +1,4 @@
+import { clearAllChild, createOptions } from '../HtmlFunc/options.js';
 import { DefaultSettings, Languages } from './defaultSettings.js';
 
 let gptModelsForOptions = {
@@ -12,31 +13,6 @@ const updateGptModelAttributeDisabled = () => {
             'disabled',
             Object.keys(gptModelsForOptions).length === 0,
         );
-};
-
-const createOptions = (selectElementId, optionsAsObjectWithKeyValue) => {
-    const selectElement = document.getElementById(selectElementId);
-    if (!selectElement) {
-        return;
-    }
-
-    for (const pair of Object.entries(optionsAsObjectWithKeyValue)) {
-        const option = document.createElement('option');
-        option.value = pair[0];
-        option.text = pair[1];
-        selectElement.appendChild(option);
-    }
-};
-
-const clearAllChild = (selectElementId) => {
-    const selectElement = document.getElementById(selectElementId);
-    if (!selectElement) {
-        return;
-    }
-
-    while (selectElement.firstChild) {
-        selectElement.firstChild.remove();
-    }
 };
 
 const loadAllGptModels = async () => {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1,13 +1,18 @@
 #translation-popup {
     --main-bg-color: white;
+    --main-color-black: black;
+    --main-color-grey-dark: #333;
+    --main-color-grey-medium: #666;
+    --main-color-grey-light: #ccc;
+    --elem-radius: 4px;
 
     position: fixed;
     top: 40vh;
     left: 50vw;
     transform: translate(-50%, max(-50%, -40vh));
     background-color: var(--main-bg-color);
-    border: 1px solid #ccc;
-    border-radius: 10px;
+    border: 1px solid var(--main-color-grey-light);
+    border-radius: 12px;
     padding: 15px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     z-index: 10000;
@@ -22,10 +27,14 @@
 #translation-popup li,
 #translation-popup div,
 #translation-popup pre {
-    color: black;
+    color: var(--main-color-black);
     font-size: 16px;
     margin: 0 0 4px;
     font-family: Arial, sans-serif;
+}
+
+#translation-popup .hidden {
+    display: none;
 }
 
 #translation-popup a {
@@ -64,7 +73,7 @@
 
 #translation-popup .translation {
     padding-right: 10px;
-    width: 95%;
+    width: calc(100% - 32px);
 }
 
 .translation-section .pronunciation {
@@ -75,12 +84,12 @@
 
 #translation-popup .explanation {
     font-size: 12px;
-    color: #666;
+    color: var(--main-color-grey-medium);
 }
 
 #translation-popup .explanation strong {
     font-weight: bold;
-    color: #333;
+    color: var(--main-color-grey-dark);
 }
 
 #translation-popup pre {
@@ -92,4 +101,43 @@
 .navbar-popup {
     width: 300px;
     font-size: 16px;
+}
+
+#translation-popup #change-lang-form {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    justify-content: start;
+    gap: 0.5em;
+    background: none;
+}
+
+#translation-popup #change-lang-form label {
+    line-height: 1.2em;
+    font-size: 1em;
+    background: none;
+}
+
+#translation-popup #change-lang-form select {
+    line-height: 1.2em;
+    font-size: 1em;
+    background: none;
+    margin: 0;
+    padding: 0 0.5em;
+    height: 1.5em;
+    width: 140px;
+    border: 1px solid var(--main-color-black);
+    border-radius: var(--elem-radius);
+    appearance: auto;
+}
+
+#translation-popup #change-lang-form button {
+    height: 1.5em;
+    line-height: 1.2em;
+    font-size: 1em;
+    padding: 0 0.5em;
+    margin: 0;
+    min-width: 90px;
+    border-radius: var(--elem-radius);
+    cursor: pointer;
 }

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -27,6 +27,6 @@
                 Disable
             </label>
         </div>
-        <script src="../scripts/popup.js"></script>
+        <script type="module" src="../popup.bundle.js"></script>
     </body>
 </html>

--- a/src/views/settings.html
+++ b/src/views/settings.html
@@ -86,6 +86,6 @@
             <button type="submit" id="save-and-close">Save and close</button>
         </form>
         <script type="module" src="../scripts/defaultSettings.js"></script>
-        <script type="module" src="../scripts/settings.js"></script>
+        <script type="module" src="../settings.bundle.js"></script>
     </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,25 @@
 const path = require('path');
+const fs = require('fs');
 
 const buildPath = path.resolve(__dirname, 'dist');
 const sourcePath = path.resolve(__dirname, 'src');
 
 const CopyPlugin = require('copy-webpack-plugin');
 
+const isDevelopment =
+    process.argv[process.argv.indexOf('--mode') + 1] === 'development';
+fs.writeFile(
+    `${sourcePath}/content/development.js`,
+    `export const IsDevelopment = ${isDevelopment};\n`,
+    () => void 0,
+);
+
 module.exports = {
-    mode: 'production',
     entry: {
         background: `${sourcePath}/background/background.js`,
         content: `${sourcePath}/content/content.js`,
+        settings: `${sourcePath}/scripts/settings.js`,
+        popup: `${sourcePath}/scripts/popup.js`,
     },
     output: {
         path: buildPath,


### PR DESCRIPTION
@johnlewissims Hi, sorry I couldn't stop at the right moment, so this pull request also includes some refactoring.

Commits:
1. https://github.com/johnlewissims/ChatGPTranslate/commit/74c7ad1f04c7223952ebc7cc3c1076b8084a74c9
- Add build mode to the CLI options
- Add src/content/development.js and code to update this file during the build process. I'm not sure these changes should be included in the production code, but I use them for local debugging.

2. https://github.com/johnlewissims/ChatGPTranslate/commit/bcb90b567c9c8ddf91bcaead6e44470565f36afe
- Refactoring.

3. https://github.com/johnlewissims/ChatGPTranslate/commit/755c61c526d8d8ed0b6f605418baa77c8c8d4c02
- Refactoring.

4. https://github.com/johnlewissims/ChatGPTranslate/commit/dfcc79798a7271f98e67451767af6290a384336a
- Add language select option to the popup form.
- Add saving a list of favorite user languages to simplify the workflow with the language selection field in the popup.

The popup now looks like this:
![image](https://github.com/user-attachments/assets/0057b515-e5f3-4dd7-9da4-f7917f876f34)

In the screen above, GPT stated that it translated the word "more" from Serbian to English as "more," but this is a mistake in GPT's response. When I select "Serbian" as the language and click "translate," I get the correct answer: "sea."

![image](https://github.com/user-attachments/assets/8d3ccd45-830f-43e6-9cc5-54a99eec29da)

The extension saves the user's most popular languages and displays them at the top of the options list:
![image](https://github.com/user-attachments/assets/58780ed1-176c-43d4-878f-f0e1a7e81005)
