### PR TITLE
Add link to the OpenAI usage and activity page

### DIFF
--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -22,6 +22,15 @@
                 >
                 page.
             </p>
+            <p>
+                GPT usage
+                <a
+                    href="https://platform.openai.com/settings/organization/usage"
+                    target="_blank"
+                    >cost and activity</a
+                >
+                pages.
+            </p>
             <div class="footer">
                 <label>
                     <input type="checkbox" id="enable-disable" checked /> Enable


### PR DESCRIPTION
@johnlewissims Hi, I sometimes review my activity and think it would be more convenient to use the link from the pop-up instead of a bookmark or googling it.