### PR TITLE
Add simple chat with GPT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat-gp-translate",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Translate selected text and provide explanations and breakdowns.",
   "main": "index.js",
   "scripts": {

--- a/src/HtmlFunc/chatElements.ts
+++ b/src/HtmlFunc/chatElements.ts
@@ -1,0 +1,14 @@
+const createChatElement = (text: string, className: string) => {
+    const elem = document.createElement('li');
+    elem.classList.add(className);
+    const textNode = document.createTextNode(text);
+    elem.appendChild(textNode);
+    return elem;
+};
+
+export const createAnswerElement = (text: string) => {
+    return createChatElement(text, 'answer');
+};
+export const createQuestionElement = (text: string) => {
+    return createChatElement(text, 'question');
+};

--- a/src/Models/ChatMessage.ts
+++ b/src/Models/ChatMessage.ts
@@ -1,0 +1,4 @@
+export type ChatMessage = {
+    message: string;
+    instruction?: string;
+};

--- a/src/Models/OpenAIExplanation.ts
+++ b/src/Models/OpenAIExplanation.ts
@@ -1,0 +1,3 @@
+export type OpenAIExplanation = {
+    explanation: string;
+};

--- a/src/Models/OpenAITranslation.ts
+++ b/src/Models/OpenAITranslation.ts
@@ -1,0 +1,3 @@
+export type OpenAITranslation = {
+    translation: string;
+};

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -1,3 +1,5 @@
 export const ErrorMessages = {
     APIKeyNotSet: 'API Key not set',
+    EmptyMessage: 'The message is empty!',
+    GptApiErrorHeader: 'GPT error:',
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "ChatGPTranslate",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Highlight text and use ChatGPT to translate and explain it.",
     "permissions": ["activeTab", "contextMenus", "storage"],
     "background": {

--- a/src/scripts/chat.ts
+++ b/src/scripts/chat.ts
@@ -1,0 +1,62 @@
+import OpenAIService from '@src/background/OpenAIService';
+import { ErrorMessages } from '@src/constants/errorMessages';
+import {
+    createAnswerElement,
+    createQuestionElement,
+} from '@src/HtmlFunc/chatElements';
+
+const showAnswer = (text: string): void => {
+    const newAnswer = createAnswerElement(text);
+    const list = document.getElementById('answers-list') as HTMLUListElement;
+    list.prepend(newAnswer);
+};
+
+const showQuestion = (text: string): void => {
+    const newAnswer = createQuestionElement(text);
+    const list = document.getElementById('answers-list') as HTMLUListElement;
+    list.prepend(newAnswer);
+};
+
+const sendQuestionToGPT = async () => {
+    const instructionInput = document.getElementById(
+        'instruction',
+    ) as HTMLInputElement;
+
+    const messageTextarea = document.getElementById(
+        'message-to-gpt',
+    ) as HTMLTextAreaElement;
+
+    const message = messageTextarea?.value?.trim() ?? '';
+    if (!message) {
+        showAnswer(ErrorMessages.EmptyMessage);
+        return;
+    }
+
+    messageTextarea.value = '';
+    showQuestion(message);
+
+    const instruction = instructionInput?.value?.trim() ?? '';
+
+    const response = await OpenAIService.sendChatMessage({
+        message,
+        instruction,
+    });
+    showAnswer(response.translation ?? ErrorMessages.EmptyMessage);
+};
+
+document.addEventListener('DOMContentLoaded', async () => {
+    document
+        .getElementById('send-message')
+        ?.addEventListener('click', sendQuestionToGPT);
+});
+
+document.addEventListener('keyup', async (event: KeyboardEvent) => {
+    if (!event.ctrlKey) {
+        return;
+    }
+
+    if (event.key === 'Enter') {
+        sendQuestionToGPT();
+        return;
+    }
+});

--- a/src/scripts/popup.ts
+++ b/src/scripts/popup.ts
@@ -8,6 +8,13 @@ document.addEventListener('DOMContentLoaded', () => {
         link.href = getURL('views/settings.html');
     });
 
+    const chatLink = document.getElementById(
+        'link-to-chat-with-GPT',
+    ) as HTMLLinkElement;
+    if (chatLink) {
+        chatLink.href = getURL('views/chat.html');
+    }
+
     chrome.storage.local.get(
         ['translation', 'explanation', 'OPENAI_API_KEY'],
         (data) => {

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -1,0 +1,124 @@
+:root {
+    --main-bg-color: white;
+    --main-color-black: black;
+    --main-color-grey-dark: #333;
+    --main-color-grey-medium: #666;
+    --main-color-grey-light: #ccc;
+    --border-color: #666;
+    --elem-radius: 4px;
+    --form-width: 900px;
+}
+
+body {
+    margin: 0;
+    font-size: 100%;
+}
+
+textarea {
+    font-size: 1rem;
+}
+
+h1 {
+    line-height: 2rem;
+    font-size: 2rem;
+    margin: 1rem;
+}
+
+ul {
+    padding-left: 1rem;
+}
+
+li {
+    padding-left: 0;
+}
+
+input,
+textarea {
+    padding: 0.25rem 0.5rem;
+}
+
+#stub {
+    color: var(--main-color-grey-medium);
+    list-style-type: none;
+}
+
+.container {
+    position: relative;
+    margin: 0 1rem;
+    box-sizing: border-box;
+}
+
+.answers-list {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 14rem);
+    padding: 0 1.5rem;
+    overflow-y: scroll;
+    max-width: var(--form-width);
+    box-sizing: border-box;
+}
+
+.question-form {
+    width: 100%;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    justify-content: start;
+    flex-direction: column;
+    align-items: start;
+    gap: 0.625rem;
+    max-width: var(--form-width);
+    min-height: 9rem;
+    padding: 0 1rem;
+    box-sizing: border-box;
+}
+
+.question-form .question-text {
+    width: 100%;
+    display: flex;
+    justify-content: start;
+    align-items: start;
+    gap: 0.625rem;
+}
+
+.question-form textarea {
+    width: calc(100% - 60px);
+    height: 4.8rem;
+    resize: none;
+    border-radius: var(--elem-radius);
+    border: 1px solid var(--border-color);
+}
+
+.question-form button {
+    width: 60px;
+    padding: 0.25rem 1rem;
+    border-radius: var(--elem-radius);
+    border: 1px solid var(--border-color);
+}
+
+.answer:not(#stub) {
+    color: var(--main-color-black);
+    list-style-type: 'A: ';
+}
+
+.question {
+    margin: 0.5rem 0;
+    font-weight: 600;
+    color: var(--main-color-grey-dark);
+    list-style-type: 'Q: ';
+}
+
+.instructions {
+    width: 100%;
+    display: flex;
+    gap: 0.625rem;
+}
+
+.instructions label {
+    flex: 0 0 auto;
+}
+
+.instructions input {
+    flex: 1 0 auto;
+}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -28,7 +28,7 @@
 #translation-popup div,
 #translation-popup pre {
     color: var(--main-color-black);
-    font-size: 1rem;
+    font-size: max(1rem, 16px);
     margin: 0 0 4px;
     font-family: Arial, sans-serif;
 }

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -28,7 +28,7 @@
 #translation-popup div,
 #translation-popup pre {
     color: var(--main-color-black);
-    font-size: max(1rem, 16px);
+    font-size: min(max(1rem, 12px), 24px);
     margin: 0 0 4px;
     font-family: Arial, sans-serif;
 }

--- a/src/views/chat.html
+++ b/src/views/chat.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+    <head>
+        <title>ChatGPTranslate chat</title>
+        <link rel="stylesheet" href="../styles/chat.css" />
+        <link rel="icon" type="image/png" href="../icons/icon.png" />
+    </head>
+
+    <body>
+        <h1>Chat (each question is independent)</h1>
+        <div class="container">
+            <ul id="answers-list" class="answers-list">
+                <li id="stub" class="answer">Answer will be shown here...</li>
+            </ul>
+            <form class="question-form">
+                <div class="instructions">
+                    <label>Instruction for GPT:</label>
+                    <input
+                        type="text"
+                        id="instruction"
+                        placeholder="It is the optional field. You may write instructions in the message."
+                    />
+                </div>
+                <div class="question-text">
+                    <textarea
+                        id="message-to-gpt"
+                        placeholder="Message text"
+                    ></textarea>
+                    <button type="button" id="send-message">Send</button>
+                </div>
+            </form>
+        </div>
+        <script type="module" src="../chat.bundle.js"></script>
+    </body>
+</html>

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -27,7 +27,7 @@
                 <a href="#" target="_blank" id="link-to-chat-with-GPT"
                     >chat with GPT</a
                 >
-                pages.
+                page.
             </p>
             <p>
                 GPT usage

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -23,6 +23,13 @@
                 page.
             </p>
             <p>
+                Open
+                <a href="#" target="_blank" id="link-to-chat-with-GPT"
+                    >chat with GPT</a
+                >
+                pages.
+            </p>
+            <p>
                 GPT usage
                 <a
                     href="https://platform.openai.com/settings/organization/usage"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ export default {
         content: `${sourcePath}/content/content`,
         settings: `${sourcePath}/scripts/settings`,
         popup: `${sourcePath}/scripts/popup`,
+        chat: `${sourcePath}/scripts/chat`,
     },
     output: {
         path: buildPath,


### PR DESCRIPTION
@johnlewissims Hi, I've added a simple chat with GTP. It can be opened from the extension popup:
![image](https://github.com/user-attachments/assets/8ee89bc2-e30a-4187-b1d0-12171d4ebc44)

You can set GPT instructions either in a separate field or within a message text:
![image](https://github.com/user-attachments/assets/cf4d4e68-3107-40be-8eb6-8bb5bb389f24)
![image](https://github.com/user-attachments/assets/e88fefbc-cd28-4608-9ea2-c570d0cc2eec)


Examples with the message: "Hi, haw are you?" and various instructions:
![image](https://github.com/user-attachments/assets/3965e457-c16d-4c2b-af58-8a9b12beff23)

![image](https://github.com/user-attachments/assets/fe067c3a-ba39-42e4-82b5-6de3785ecc9d)
